### PR TITLE
parse string in css format 'rgb(12,34,56)'

### DIFF
--- a/colorist.gemspec
+++ b/colorist.gemspec
@@ -6,7 +6,6 @@ Gem::Specification.new do |s|
   s.email = "michael@intridea.com"
   s.homepage = "http://github.com/mbleigh/colorist"
   s.description = "Colorist is a library built to handle the easy conversion and manipulation of colors with a special emphasis on W3C standards and CSS-style hex color notation."
-  s.has_rdoc = true
   s.authors = ["Michael Bleigh"]
   s.files = [ "MIT_LICENSE.rdoc",
               "README.rdoc",
@@ -14,7 +13,7 @@ Gem::Specification.new do |s|
               "lib/colorist.rb",
               "lib/colorist/color.rb",
               "lib/colorist/core_extensions.rb" ]
-	s.add_development_dependency 'rake'
+  s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 2.8'
   s.rdoc_options = ["--main", "README.rdoc"]
   s.extra_rdoc_files = ["MIT_LICENSE.rdoc", "README.rdoc"]

--- a/lib/colorist/color.rb
+++ b/lib/colorist/color.rb
@@ -228,8 +228,10 @@ module Colorist
     #  # Other X11 color (case insensitive)
     #  color = Colorist::Color.from_string "Dark Olive Green", :x11 # => <Color #556B2F>
     def self.from_string(some_string, standard=:w3c)
-      some_string = some_string.downcase.sub(/ /, "_")
-      if matched = some_string.match(/\A#([0-9a-f]{3})\z/i)
+      some_string = some_string.downcase.gsub(/ /, "_")
+      if matched = some_string.match(/\Argb\(_*(\d+),_*(\d+),_*(\d+)_*\)\z/i)
+        color = Colorist::Color.from_rgb matched[1].to_i, matched[2].to_i, matched[3].to_i
+      elsif matched = some_string.match(/\A#([0-9a-f]{3})\z/i)
         color = Colorist::Color.from_rgb(*matched[1].split(//).collect{|v| "#{v}#{v}".hex })
       elsif matched = some_string.match(/\A#([0-9a-f]{6})\z/i)
         color = Colorist::Color.new

--- a/lib/colorist/color.rb
+++ b/lib/colorist/color.rb
@@ -2,9 +2,9 @@ module Colorist
   # Color is the general class for storing and manipulating a color with the
   # Colorist gem. It provides methods to add, subtract, and calculate aspects
   # of the color based on W3C and other standards.
-  class Color            
+  class Color
     attr_accessor :r, :g, :b
-  
+
     W3C_COLOR_NAMES = {  "maroon"  => 0x800000,
                          "red"     => 0xff0000,
                          "orange"  => 0xffa500,
@@ -169,7 +169,7 @@ module Colorist
       @g = string[2..3].hex
       @b = string[4..5].hex
     end
-    
+
     # Initialize a color based on RGB values. By default, the values
     # should be between 0 and 255. If you use the option <tt>:percent => true</tt>,
     # the values should then be between 0.0 and 1.0.
@@ -183,21 +183,21 @@ module Colorist
       end
       color
     end
-    
+
     # Initialize a colour based on HSV/HSB values. Hue should be between 0 and 360 (inclusive),
     # while saturation and value should be from 0.0 to 1.0.
     def self.from_hsv(hue, saturation, value)
       saturation = 1 if saturation > 1
       value = 1 if saturation > 1
-      
+
       # Conversion formula taken from wikipedia
-      
+
       f = (hue / 60.0) - (hue / 60)
-      
+
       p = value * (1 - saturation)
       q = value * (1 - (saturation * f))
       t = value * (1 - (saturation * (1 - f)))
-      
+
       case ((hue / 60) % 6).floor
         when 0 then from_rgb(value, t, p, :percent => true)
         when 1 then from_rgb(q, value, p, :percent => true)
@@ -207,19 +207,19 @@ module Colorist
         when 5 then from_rgb(value, p, q, :percent => true)
       end
     end
-        
+
     # Converts a W3C hex string into a color. Works both with the
     # full form (i.e. <tt>#ffffff</tt>) and the abbreviated form (<tt>#fff</tt>). Can
     # also take any of the 16 named W3C colors.
-    # Specify a standard if you enter the key word as defined by the standard you use, the 
+    # Specify a standard if you enter the key word as defined by the standard you use, the
     # available standards are :
     #
     # * <tt>:w3c</tt> - Used by default, represent W3C colors specified in W3C_COLOR_NAMES constant
     # * <tt>:x11</tt> - represent X11 standard colors specified in X11_COLOR_NAMES constant
     #
     # Examples :
-    #  
-    #  # Here we can ommit standard parameter (:w3c by default) 
+    #
+    #  # Here we can ommit standard parameter (:w3c by default)
     #  color = Colorist::Color.from_string "gray" # => <Color #808080>
     #
     #  # For X11 standard (gray hex value is different)
@@ -255,7 +255,7 @@ module Colorist
       end
       color
     end
-    
+
     # Create a new color from the provided object. Duplicates Color objects
     # and attempts to call <tt>to_color</tt> on other objects. Will raise
     # an ArgumentError if it is unable to coerce the color.
@@ -268,12 +268,12 @@ module Colorist
           some_entity.to_color
       end
     end
-  
+
     # Create a duplicate of this color.
     def dup
       Colorist::Color.from_rgb(@r,@g,@b)
     end
-  
+
     # Add the individual RGB values of two colors together. You
     # may also use an equivalent numeric or string color representation.
     #
@@ -292,7 +292,7 @@ module Colorist
       color.b += other_color.b
       color
     end
-  
+
     # Subtract the individual RGB values of the two colors together.
     # You may also use an equivalent numeric or string color representation.
     def -(other_color)
@@ -303,44 +303,44 @@ module Colorist
       color.b -= other_color.b
       color
     end
-    
+
     # Compares colors based on brightness.
     def <=>(other_color)
       other_color = Colorist::Color.from(other_color)
       brightness <=> other_color.brightness
     end
-    
+
     # Compares colors based on brightness.
     def < (other_color)
       other_color = Colorist::Color.from(other_color)
       brightness < other_color.brightness
     end
-    
+
     # Compares colors based on brightness.
     def > (other_color)
       other_color = Colorist::Color.from(other_color)
       brightness > other_color.brightness
     end
-    
+
     # Equal if the red, green, and blue values are identical.
     def ==(other_color)
       other_color = Colorist::Color.from(other_color)
       other_color.r == self.r && other_color.g == self.g && other_color.b == self.b
     end
-    
+
     # Equal if the brightnesses of the two colors are identical.
     def ===(other_color)
       other_color = Colorist::Color.from(other_color)
       other_color.brightness == brightness
     end
-    
+
     def r=(value) #:nodoc:
-      @r = value; normalize; end 
+      @r = value; normalize; end
     def g=(value) #:nodoc:
       @g = value; normalize; end
     def b=(value) #:nodoc:
       @b = value; normalize; end
-  
+
     # Outputs a string representation of the color in the desired format.
     # The available formats are:
     #
@@ -357,7 +357,7 @@ module Colorist
           "%.3f, %.3f, %.3f" % [r / 255, g / 255, b / 255]
       end
     end
-    
+
     # Returns an array of the hue, saturation and value of the color.
     # Hue will range from 0-359, hue and saturation will be between 0 and 1.
 
@@ -379,16 +379,16 @@ module Colorist
       saturation = (max == 0) ? 0 : (max - min) / max
       [hue % 360, saturation, max]
     end
-  
+
     def inspect
       "#<Color #{to_s(:css)}>"
     end
-  
+
     # Returns the perceived brightness of the provided color on a
     # scale of 0.0 to 1.0 based on the formula provided. The formulas
     # available are:
     #
-    # * <tt>:w3c</tt> - <tt>((r * 299 + g * 587 + b * 114) / 1000 / 255</tt>    
+    # * <tt>:w3c</tt> - <tt>((r * 299 + g * 587 + b * 114) / 1000 / 255</tt>
     # * <tt>:standard</tt> - <tt>sqrt(0.241 * r^2 + 0.691 * g^2 + 0.068 * b^2) / 255</tt>
     def brightness(formula=:w3c)
       case formula
@@ -398,7 +398,7 @@ module Colorist
           ((r * 299 + g * 587 + b * 114) / 255000.0)
       end
     end
-    
+
     # Contrast this color with another color using the provided formula. The
     # available formulas are:
     #
@@ -412,12 +412,12 @@ module Colorist
           ([self.b, other_color.b].max - [self.b, other_color.b].min)) / 765.0
       end
     end
-    
+
     # Returns the opposite of the current color.
     def invert
       Color.from_rgb(255 - r, 255 - g, 255 - b)
     end
-        
+
     # Uses a naive formula to generate a gradient between this color and the given color.
     # Returns the array of colors that make the gradient, including this color and the
     # target color.  By default will return 10 colors, but this can be changed by supplying
@@ -427,36 +427,36 @@ module Colorist
       red = color_to.r - r
       green = color_to.g - g
       blue = color_to.b - b
-            
+
       result = (1..(steps - 3)).to_a.collect do |step|
         percentage = step.to_f / (steps - 1)
         Color.from_rgb(r + (red * percentage), g + (green * percentage), b + (blue * percentage))
       end
-      
+
       # Add first and last colors to result, avoiding uneccessary calculation and rounding errors
-      
+
       result.unshift(self.dup)
       result.push(color.dup)
       result
     end
-    
+
     # Converts the current color to grayscale using the brightness
-    # formula provided. See #brightness for a description of the 
+    # formula provided. See #brightness for a description of the
     # available formulas.
     def to_grayscale(formula=:w3c)
       b = brightness(formula)
       Color.from_rgb(255 * b, 255 * b, 255 * b)
     end
-  
+
     # Returns an appropriate text color (either black or white) based on
     # the brightness of this color. The +threshold+ specifies the brightness
     # cutoff point.
     def text_color(threshold=0.6, formula=:standard)
       brightness(formula) > threshold ? Colorist::Color.new(0x000000) : Colorist::Color.new(0xffffff)
     end
-  
+
     protected
-  
+
     def normalize #:nodoc:
       @r = 255 if @r > 255
       @g = 255 if @g > 255

--- a/spec/colorist/color_spec.rb
+++ b/spec/colorist/color_spec.rb
@@ -37,6 +37,14 @@ describe Colorist::Color do
 	
 	describe "#2 From entity" do
 		
+		it "should return the color from css rgb string rgb(12,34, 56)" do
+			Colorist::Color.from_string("rgb(12,34, 56)").to_s.should == "#0c2238"
+		end
+
+		it "should return the color ignoring whitespace from css rgb string rgb( 65, 43, 21 )" do
+			Colorist::Color.from_string("rgb( 65, 43, 21 )").to_s.should == "#412b15"
+		end
+
 		it "should return the color from css string (#121212)" do
 			Colorist::Color.from_string("#121212").to_s.should == "#121212"
 		end


### PR DESCRIPTION
So we can use, for example:

> "rgb(128,128,128)".to_color

or similarly,

> Colorist::Color.from_string("rgb( 1, 2, 3 )")